### PR TITLE
refactor(tokenAuth): refactor tokenAuth middleware

### DIFF
--- a/core/settings.go
+++ b/core/settings.go
@@ -47,5 +47,5 @@ func GlobalMiddlewareInit(router *gin.Engine) {
 
 // Custom midleware settings (for specific API)
 func MiddlewareInit(router *gin.Engine) {
-	middleware.TokenAuthMiddleware(router)
+	// middleware.TokenAuthMiddleware(router, os.Getenv('yourtokenname'))
 }

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -1,18 +1,16 @@
 package middleware
 
 import (
-	"os"
-
 	"github.com/gin-gonic/gin"
 )
 
-func TokenAuthMiddleware(router *gin.Engine) {
-	router.Use(tokenAuthHandler())
+func TokenAuthMiddleware(router *gin.Engine, token string) {
+	router.Use(tokenAuthHandler(token))
 }
 
-func tokenAuthHandler() gin.HandlerFunc {
+func tokenAuthHandler(token string) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if os.Getenv("TOKEN") != c.Request.Header.Get("Authentication") {
+		if token != c.Request.Header.Get("Token-Authentication") {
 			c.AbortWithStatusJSON(
 				400,
 				gin.H{"error": "No auth"},


### PR DESCRIPTION
1. Change keyword of request header
2. Retrieve the token by using the input argument instead of directly reading from os.Getenv.